### PR TITLE
Update manifest.json to refine URL patterns

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,7 @@
   "content_scripts": [
     {
       "matches": [
-        "*/time-tracker"
+        "*://*/time-tracker/*"
       ],
       "js": [
         "index.global.min.js",
@@ -32,7 +32,7 @@
     }
   ],
   "host_permissions": [
-    "*/time-tracker"
+    "*://*/time-tracker/*"
   ],
   "action": {},
   "devtools_page": "devtools.html"


### PR DESCRIPTION
I have a MacBook Pro with macOS 15.1 using Chrome Version 130.0.6723.70 (Official Build) (arm64) and I tried following the instructions from the tutorial on the README, but it failed to load with the following error:

```
Failed to load extension
File ~/Downloads/bd-timetacker-calendarview
Error Invalid value for 'content_scripts[0].matches[0]': Missing scheme separator.
Could not load manifest.
```

This PR updates the `manifest.json` to refine URL patterns for content scripts and host permissions.